### PR TITLE
Handling of missing content-type headers breaks POST

### DIFF
--- a/repoze/who/_compat.py
+++ b/repoze/who/_compat.py
@@ -84,7 +84,7 @@ def REQUEST_METHOD(environ):
     return environ['REQUEST_METHOD']
 
 def CONTENT_TYPE(environ):
-    return environ['CONTENT_TYPE']
+    return environ.get('CONTENT_TYPE', '')
 
 def USER_AGENT(environ):
     return environ.get('HTTP_USER_AGENT')

--- a/repoze/who/tests/test__compat.py
+++ b/repoze/who/tests/test__compat.py
@@ -18,7 +18,7 @@ class CompatTests(unittest.TestCase):
 
     def test_CONTENT_TYPE_miss(self):
         from .._compat import CONTENT_TYPE
-        self.assertRaises(KeyError, CONTENT_TYPE, {})
+        self.assertEqual(CONTENT_TYPE({}), '')
 
     def test_CONTENT_TYPE_hit(self):
         from .._compat import CONTENT_TYPE


### PR DESCRIPTION
When receiving an empty HTTP POST request from Apache using mod_wsgi or proxy_mod_wsgi, there is no CONTENT_TYPE item in the environ dict.

As far as I can gather, content-type is not a required header for POST requests. So, if I'm not mistaken, repoze/who/_compat.py should handle that condition without throwing an exception.

So, here is my proposed solution. If I am mistaken, though, I'd be happy for some guidance as to how this situation should be handled.
