### PR TITLE
Can't pass in template strings in ini config file

### DIFF
--- a/repoze/who/_compat.py
+++ b/repoze/who/_compat.py
@@ -34,9 +34,9 @@ else: #pragma NO COVER Python >= 3.0
     from urllib.parse import parse_qsl
 
 try:
-    from ConfigParser import RawConfigParser
+    from ConfigParser import RawConfigParser as ConfigParser
 except ImportError: #pragma NO COVER Python >= 3.0
-    from configparser import RawConfigParser
+    from configparser import RawConfigParser as ConfigParser
     from configparser import ParsingError
 else: #pragma NO COVER Python < 3.0
     from ConfigParser import ParsingError


### PR DESCRIPTION
I followed the examples from
http://docs.repoze.org/who/2.0/configuration.html#configuring-repoze-who-via-config-file

query = "SELECT userid, password FROM users where login = %(login)s;"

However, ConfigParser's spilling out the following exception:
ConfigParser.InterpolationMissingOptionError: Bad value substitution:

To be able to specific template strings with ConfigParser, one has to use RawConfigParser. 
