### PR TITLE
Cookie expiry date does not conform to RFC 2616 (http://tools.ietf.org/html/rfc2616#section-3.3.1 )

### DIFF
--- a/repoze/who/plugins/auth_tkt.py
+++ b/repoze/who/plugins/auth_tkt.py
@@ -1,4 +1,6 @@
 import datetime
+from calendar import timegm
+from email.utils import formatdate
 from codecs import utf_8_decode
 from codecs import utf_8_encode
 import os
@@ -168,7 +170,7 @@ class AuthTktCookiePlugin(object):
             max_age = int(max_age)
             later = _now() + datetime.timedelta(seconds=max_age)
             # Wdy, DD-Mon-YY HH:MM:SS GMT
-            expires = later.strftime('%a, %d %b %Y %H:%M:%S')
+            expires = formatdate(timegm(later.timetuple()), usegmt=True)
             # the Expires header is *required* at least for IE7 (IE7 does
             # not respect Max-Age)
             max_age = "; Max-Age=%s; Expires=%s" % (max_age, expires)

--- a/repoze/who/plugins/tests/test_authtkt.py
+++ b/repoze/who/plugins/tests/test_authtkt.py
@@ -443,36 +443,70 @@ class TestAuthTktCookiePlugin(unittest.TestCase):
                          ('Set-Cookie',
                           'auth_tkt="%s"; Path=/' % new_val))
 
+    def test_l10n_sane_cookie_date(self):
+        import locale
+        from datetime import datetime
+
+        try:
+            locale.setlocale(locale.LC_ALL, ('nb_NO', 'UTF-8'))
+
+            now = datetime(2009, 11, 8, 16, 15, 22)
+            self._setNowTesting(now)
+
+            plugin = self._makeOne('secret')
+            environ = {'HTTP_HOST': 'example.com'}
+
+            tkt = self._makeTicket(userid='chris', userdata='')
+
+
+            result = plugin.remember(environ, {'repoze.who.userid': 'chris',
+                                               'max_age': '500'})
+            name, value = result.pop(0)
+
+            self.assertEqual('Set-Cookie', name)
+            self.failUnless(
+                value.endswith('; Expires=Sun, 08 Nov 2009 16:23:42 GMT'))
+        finally:
+            locale.resetlocale(locale.LC_ALL)
+
     def test_remember_max_age(self):
+        from datetime import datetime
+
+        now = datetime(2009, 11, 8, 16, 15, 22)
+        self._setNowTesting(now)
+
         plugin = self._makeOne('secret')
-        environ = {'HTTP_HOST':'example.com'}
-        
+        environ = {'HTTP_HOST': 'example.com'}
+
         tkt = self._makeTicket(userid='chris', userdata='')
-        result = plugin.remember(environ, {'repoze.who.userid':'chris',
-                                           'max_age':'500'})
-        
-        name,value = result.pop(0)
+        result = plugin.remember(environ, {'repoze.who.userid': 'chris',
+                                           'max_age': '500'})
+
+        name, value = result.pop(0)
         self.assertEqual('Set-Cookie', name)
         self.failUnless(
             value.startswith('auth_tkt="%s"; Path=/; Max-Age=500' % tkt),
             value)
-        self.failUnless('; Expires=' in value)
-        
-        name,value = result.pop(0)
-        self.assertEqual('Set-Cookie', name)
         self.failUnless(
-            value.startswith(
-            'auth_tkt="%s"; Path=/; Domain=example.com; Max-Age=500'
-            % tkt), value)
-        self.failUnless('; Expires=' in value)
+            value.endswith('; Expires=Sun, 08 Nov 2009 16:23:42 GMT'))
 
-        name,value = result.pop(0)
+        name, value = result.pop(0)
         self.assertEqual('Set-Cookie', name)
         self.failUnless(
             value.startswith(
-            'auth_tkt="%s"; Path=/; Domain=.example.com; Max-Age=500' % tkt),
+                'auth_tkt="%s"; Path=/; Domain=example.com; Max-Age=500'
+                % tkt), value)
+        self.failUnless(
+            value.endswith('; Expires=Sun, 08 Nov 2009 16:23:42 GMT'))
+
+        name, value = result.pop(0)
+        self.assertEqual('Set-Cookie', name)
+        self.failUnless(
+            value.startswith(
+                'auth_tkt="%s"; Path=/; Domain=.example.com; Max-Age=500' % tkt),
             value)
-        self.failUnless('; Expires=' in value)
+        self.failUnless(
+            value.endswith('; Expires=Sun, 08 Nov 2009 16:23:42 GMT'))
 
     def test_forget(self):
         from datetime import datetime
@@ -487,21 +521,21 @@ class TestAuthTktCookiePlugin(unittest.TestCase):
         self.assertEqual(name, 'Set-Cookie')
         self.assertEqual(value,
                          'auth_tkt="INVALID"; Path=/; '
-                         'Max-Age=0; Expires=Thu, 05 Nov 2009 16:15:22'
+                         'Max-Age=0; Expires=Thu, 05 Nov 2009 16:15:22 GMT'
                          )
         header = headers[1]
         name, value = header
         self.assertEqual(name, 'Set-Cookie')
         self.assertEqual(value,
                          'auth_tkt="INVALID"; Path=/; Domain=localhost; '
-                         'Max-Age=0; Expires=Thu, 05 Nov 2009 16:15:22'
+                         'Max-Age=0; Expires=Thu, 05 Nov 2009 16:15:22 GMT'
                          )
         header = headers[2]
         name, value = header
         self.assertEqual(name, 'Set-Cookie')
         self.assertEqual(value,
                          'auth_tkt="INVALID"; Path=/; Domain=.localhost; '
-                         'Max-Age=0; Expires=Thu, 05 Nov 2009 16:15:22'
+                         'Max-Age=0; Expires=Thu, 05 Nov 2009 16:15:22 GMT'
                         )
 
     def test_authenticate_non_auth_tkt_credentials(self):


### PR DESCRIPTION
The Expires field is susceptible to locale changes and does not end with 'GMT'.
