### PR TITLE
Expand authtkt checksums

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 language: python
 sudo : false
 
+python:
+    - "3.5"
+
 env:
   - TOXENV=py26
   - TOXENV=py27
@@ -13,7 +16,8 @@ env:
   - TOXENV=cover
 
 install:
-  - travis_retry pip install tox
+  # virtualenv >= 14.0.0 has dropped support for Python 3.2
+  - travis_retry pip install "virtualenv<14.0.0" tox
 
 script:
   - travis_retry tox

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -103,7 +103,7 @@ An example configuration which uses the default plugins follows::
         return password == hashed
     htpasswd = HTPasswdPlugin(io, cleartext_check)
     basicauth = BasicAuthPlugin('repoze.who')
-    auth_tkt = AuthTktCookiePlugin('secret', 'auth_tkt')
+    auth_tkt = AuthTktCookiePlugin('secret', 'auth_tkt', digest_algo="sha512")
     redirector = RedirectorPlugin('/login.html')
     redirector.classifications = {IChallenger:['browser'],} # only for browser
     identifiers = [('auth_tkt', auth_tkt),
@@ -220,6 +220,7 @@ nominated to act as authenticator plugins. ::
     cookie_name = oatmeal
     secure = False
     include_ip = False
+    digest_algo = sha512
 
     [plugin:basicauth]
     # identification and challenge

--- a/docs/examples/hybrid/example.py
+++ b/docs/examples/hybrid/example.py
@@ -183,7 +183,7 @@ if __name__ == '__main__':
 
     ## other plugins
     basicauth = BasicAuthPlugin('repoze.who')
-    auth_tkt = AuthTktCookiePlugin('secret', 'auth_tkt')
+    auth_tkt = AuthTktCookiePlugin('secret', 'auth_tkt', digest_algo="sha512")
     redirector = RedirectorPlugin(login_url='/login.html')
     redirector.classifications = {IChallenger:['browser'] } # only for browser
 

--- a/docs/examples/standalone_login.py
+++ b/docs/examples/standalone_login.py
@@ -44,6 +44,7 @@ secret = s33kr1t
 cookie_name = auth_cookie
 secure = True
 include_ip = True
+digest_algo = sha512
 
 [general]
 request_classifier = repoze.who.classifiers:default_request_classifier

--- a/docs/examples/standalone_login_no_who.py
+++ b/docs/examples/standalone_login_no_who.py
@@ -75,7 +75,8 @@ def login(environ, start_response):
         if _validate(login_name, password):
             headers = [('Location', came_from)]
             ticket = auth_tkt.AuthTicket(SECRET, login_name, remote_addr,
-                                         cookie_name=COOKIE_NAME, secure=True)
+                                         cookie_name=COOKIE_NAME, secure=True,
+                                         digest_algo="sha512")
             headers = _get_cookies(environ, ticket.cookie_value())
             headers.append(('Location', came_from))
             start_response('302 Found', headers)

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -69,7 +69,8 @@ authentication, identification, challenge and metadata provision.
 
   An :class:`AuthTktCookiePlugin` is an ``IIdentifier`` and ``IAuthenticator``
   plugin which remembers its identity state in a client-side cookie.
-  This plugin uses the ``paste.auth.auth_tkt``"auth ticket" protocol.
+  This plugin uses the ``paste.auth.auth_tkt``"auth ticket" protocol and
+  is compatible with Apache's mod_auth_tkt.
   It should be instantiated passing a *secret*, which is used to encrypt the
   cookie on the client side and decrypt the cookie on the server side.
   The cookie name used to store the cookie value can be specified
@@ -95,6 +96,13 @@ authentication, identification, challenge and metadata provision.
    Data will then be returned every time by ``identify``. This dict must be compatible with
    ``urllib.urlencode`` function (``urllib.urlparse.urlencode`` in python 3).
    Saving keys/values with unicode characters is supported only under python 3.
+
+.. note::
+   Plugin supports multiple digest algorithms. It defaults to md5 to match
+   the default for mod_auth_tkt and paste.auth.auth_tkt. However md5 is not
+   recommended as there are viable attacks against the hash. Any algorithm
+   from the hashlib library can be specified, currently only sha256 and sha512
+   are supported by mod_auth_tkt.
 
 .. module:: repoze.who.plugins.basicauth
 

--- a/repoze/who/tests/test__auth_tkt.py
+++ b/repoze/who/tests/test__auth_tkt.py
@@ -37,36 +37,36 @@ class AuthTicketTests(unittest.TestCase):
         self.assertEqual(tkt.secure, True)
 
     def test_digest(self):
-        from .._auth_tkt import calculate_digest
+        from .._auth_tkt import calculate_digest, hashlib
         tkt = self._makeOne('SEEKRIT', 'USERID', '1.2.3.4', tokens=('a', 'b'),
                             user_data='DATA', time=_WHEN,
                             cookie_name='oatmeal', secure=True)
         digest = calculate_digest('1.2.3.4', _WHEN, 'SEEKRIT', 'USERID',
-                                  'a,b', 'DATA')
+                                  'a,b', 'DATA', hashlib.md5)
         self.assertEqual(tkt.digest(), digest)
 
     def test_cookie_value_wo_tokens_or_userdata(self):
-        from .._auth_tkt import calculate_digest
+        from .._auth_tkt import calculate_digest, hashlib
         tkt = self._makeOne('SEEKRIT', 'USERID', '1.2.3.4', time=_WHEN)
-        digest = calculate_digest('1.2.3.4', _WHEN, 'SEEKRIT', 'USERID', '', '')
+        digest = calculate_digest('1.2.3.4', _WHEN, 'SEEKRIT', 'USERID', '', '', hashlib.md5)
         self.assertEqual(tkt.cookie_value(),
                          '%s%08xUSERID!' % (digest, _WHEN))
 
     def test_cookie_value_w_tokens_and_userdata(self):
-        from .._auth_tkt import calculate_digest
+        from .._auth_tkt import calculate_digest, hashlib
         tkt = self._makeOne('SEEKRIT', 'USERID', '1.2.3.4', tokens=('a', 'b'),
                             user_data='DATA', time=_WHEN)
         digest = calculate_digest('1.2.3.4', _WHEN, 'SEEKRIT', 'USERID',
-                                  'a,b', 'DATA')
+                                  'a,b', 'DATA', hashlib.md5)
         self.assertEqual(tkt.cookie_value(),
                          '%s%08xUSERID!a,b!DATA' % (digest, _WHEN))
 
     def test_cookie_not_secure_wo_tokens_or_userdata(self):
-        from .._auth_tkt import calculate_digest
+        from .._auth_tkt import calculate_digest, hashlib
         from .._compat import encodestring
         tkt = self._makeOne('SEEKRIT', 'USERID', '1.2.3.4', time=_WHEN,
                             cookie_name='oatmeal')
-        digest = calculate_digest('1.2.3.4', _WHEN, 'SEEKRIT', 'USERID', '', '')
+        digest = calculate_digest('1.2.3.4', _WHEN, 'SEEKRIT', 'USERID', '', '', hashlib.md5)
         cookie = tkt.cookie()
         self.assertEqual(cookie['oatmeal'].value,
                          encodestring('%s%08xUSERID!' % (digest, _WHEN)
@@ -75,13 +75,13 @@ class AuthTicketTests(unittest.TestCase):
         self.assertEqual(cookie['oatmeal']['secure'], '')
 
     def test_cookie_secure_w_tokens_and_userdata(self):
-        from .._auth_tkt import calculate_digest
+        from .._auth_tkt import calculate_digest, hashlib
         from .._compat import encodestring
         tkt = self._makeOne('SEEKRIT', 'USERID', '1.2.3.4', tokens=('a', 'b'),
                             user_data='DATA', time=_WHEN,
                             cookie_name='oatmeal', secure=True)
         digest = calculate_digest('1.2.3.4', _WHEN, 'SEEKRIT', 'USERID',
-                                  'a,b', 'DATA')
+                                  'a,b', 'DATA', hashlib.md5)
         cookie = tkt.cookie()
         self.assertEqual(cookie['oatmeal'].value,
                          encodestring('%s%08xUSERID!a,b!DATA' % (digest, _WHEN)
@@ -148,8 +148,8 @@ class Test_parse_ticket(unittest.TestCase):
             self.fail('Did not raise')
 
     def test_wo_tokens_or_data_ok_digest(self):
-        from .._auth_tkt import calculate_digest
-        digest = calculate_digest('1.2.3.4', _WHEN, 'SEEKRIT', 'USERID', '', '')
+        from .._auth_tkt import calculate_digest, hashlib
+        digest = calculate_digest('1.2.3.4', _WHEN, 'SEEKRIT', 'USERID', '', '', hashlib.md5)
         TICKET = '%s%08xUSERID!' % (digest, _WHEN)
         timestamp, userid, tokens, user_data = self._callFUT(ticket=TICKET)
         self.assertEqual(timestamp, _WHEN)
@@ -158,9 +158,9 @@ class Test_parse_ticket(unittest.TestCase):
         self.assertEqual(user_data, '')
 
     def test_w_tokens_and_data_ok_digest(self):
-        from .._auth_tkt import calculate_digest
+        from .._auth_tkt import calculate_digest, hashlib
         digest = calculate_digest('1.2.3.4', _WHEN, 'SEEKRIT', 'USERID',
-                                  'a,b', 'DATA')
+                                  'a,b', 'DATA', hashlib.md5)
         TICKET = '%s%08xUSERID!a,b!DATA' % (digest, _WHEN)
         timestamp, userid, tokens, user_data = self._callFUT(ticket=TICKET)
         self.assertEqual(timestamp, _WHEN)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = 
-    py26,py27,pypy,py32,py33,py34,pypy3,cover,docs
+    py26,py27,pypy,py32,py33,py34,py35,pypy3,cover,docs
 
 [testenv]
 commands = 


### PR DESCRIPTION
This fixes #22, authtkt only supporting MD5 checksums

It is an alternative to pull-request #23 by @frostyfrog
The main differences are:
 * I tried to remain as faithful as possible to the upstream paste/authtkt implementation
 * I did not change the default from MD5, to maintain compatibility
 * I got carried away and took things a bit further

The pull-request is a touch large but broken in to several commits to allow cherrypicking or elements to be carved off as desired.

Work done was:
 1. Pulled in changes from paste/authtkt which expand the supported checksums. I based these off paste HEAD rather than try and apply their patches.  All changes to _auth_tkt.py where based on upstream however it is not a synchronised file, changes made to the repoze branch were retained.
 2. Expanded test coverage in test__auth_tkt.py to cover alternate digests.
 3. Tweaked travis and tox files to fix an issue with the latest virtualenv no longer supporting python 3.2. Testing was also expanded to cover python 3.5.
 4. Added alternate hash support to plugins/auth_tkt.py and expanded test coverage.
 5. Modified documentation to cover alternative digests. The boilerplate examples have all been updated to use sha512.