### PR TITLE
sha1_check breaks in python3 due to % substitution of bytes

### DIFF
--- a/repoze/who/plugins/htpasswd.py
+++ b/repoze/who/plugins/htpasswd.py
@@ -101,6 +101,8 @@ def sha1_check(password, hashed):
     from base64 import standard_b64encode
     from repoze.who._compat import must_encode
     encrypted_string = standard_b64encode(sha1(must_encode(password)).digest())
+    if hasattr(encrypted_string, "decode"):
+        encrypted_string = encrypted_string.decode()
     return _same_string(hashed, "%s%s" % ("{SHA}", encrypted_string))
 
 def plain_check(password, hashed):


### PR DESCRIPTION
Mainly for documenting, this seems to break under python3.

The better solution seems to be to shift to bcrypt and redefine check_fn parameter:

import bcrypt
def bcrypt_check(password, hashed):
    return bcrypt.checkpw(password.encode(), hashed.encode())

