### PR TITLE
Support SameSite for authtkt cookie

### DIFF
--- a/repoze/who/plugins/auth_tkt.py
+++ b/repoze/who/plugins/auth_tkt.py
@@ -49,7 +49,8 @@ class AuthTktCookiePlugin(object):
     def __init__(self, secret, cookie_name='auth_tkt',
                  secure=False, include_ip=False,
                  timeout=None, reissue_time=None, userid_checker=None,
-                 digest_algo=auth_tkt.DEFAULT_DIGEST):
+                 digest_algo=auth_tkt.DEFAULT_DIGEST,
+                 samesite=None):
         self.secret = secret
         self.cookie_name = cookie_name
         self.include_ip = include_ip
@@ -61,6 +62,7 @@ class AuthTktCookiePlugin(object):
         self.reissue_time = reissue_time
         self.userid_checker = userid_checker
         self.digest_algo = digest_algo
+        self.samesite = samesite
 
     # IIdentifier
     def identify(self, environ):
@@ -196,6 +198,9 @@ class AuthTktCookiePlugin(object):
         secure = ''
         if self.secure:
             secure = '; secure; HttpOnly'
+
+        if self.samesite:
+            secure += '; SameSite=%s' % self.samesite
 
         cur_domain = environ.get('HTTP_HOST', environ.get('SERVER_NAME'))
         cur_domain = cur_domain.split(':')[0] # drop port

--- a/repoze/who/plugins/tests/test_authtkt.py
+++ b/repoze/who/plugins/tests/test_authtkt.py
@@ -296,6 +296,35 @@ class TestAuthTktCookiePlugin(unittest.TestCase):
                            'secure; HttpOnly'
                             % val))
 
+    def test_remember_creds_samesite(self):
+        plugin = self._makeOne('secret', secure=False, samesite="Strict")
+        val = self._makeTicket(userid='userid', secure=False, userdata='foo=123')
+        environ = self._makeEnviron()
+        result = plugin.remember(environ, {'repoze.who.userid':'userid',
+                                           'userdata':{'foo':'123'}})
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0],
+                         ('Set-Cookie',
+                          'auth_tkt="%s"; '
+                          'Path=/; '
+                          'SameSite=Strict' 
+                          % val))
+        self.assertEqual(result[1],
+                         ('Set-Cookie',
+                           'auth_tkt="%s"; '
+                           'Path=/; '
+                           'Domain=localhost; '
+                           'SameSite=Strict'
+                            % val))
+        self.assertEqual(result[2],
+                         ('Set-Cookie',
+                           'auth_tkt="%s"; '
+                           'Path=/; '
+                           'Domain=.localhost; '
+                           'SameSite=Strict'
+                            % val))
+
+
     def test_remember_creds_different(self):
         plugin = self._makeOne('secret')
         old_val = self._makeTicket(userid='userid')

--- a/repoze/who/tests/test__auth_tkt.py
+++ b/repoze/who/tests/test__auth_tkt.py
@@ -111,7 +111,7 @@ class AuthTicketTests(unittest.TestCase):
                                      ).strip())
         self.assertEqual(cookie['oatmeal']['path'], '/')
         self.assertEqual(cookie['oatmeal']['secure'], 'true')
- 
+
 
 class BadTicketTests(unittest.TestCase):
 


### PR DESCRIPTION
Add support for setting a `SameSite=...` option on the authtkt plugin cookie.