### PR TITLE
Disallow separators in AuthTicket component values.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,12 @@ repoze.who Changelog
 2.4.1 (unreleased)
 ------------------
 
+- Disallow separators in AuthTicket component values.  Closes #37.
+
 - Handle bytes / string correctly in 'repoze.who.plugins.htpasswd.sha1_check'.
   Closes #28.
 
-- Switch to use ``pytest`` as the testrunner.
+- Switch to use ``pytest`` as the testrunner.  Closes #34.
 
 2.4 (2020-06-03)
 ----------------

--- a/repoze/who/tests/test__auth_tkt.py
+++ b/repoze/who/tests/test__auth_tkt.py
@@ -25,6 +25,42 @@ class AuthTicketTests(unittest.TestCase):
         self.assertEqual(tkt.secure, False)
         self.assertEqual(tkt.digest_algo, hashlib.md5)
 
+    def test_ctor_w_userid_w_embedded_bang(self):
+        tokens = ('a,b',)  # cannot be safely round-tripped
+
+        with self.assertRaises(ValueError) as exc:
+            self._makeOne('SEEKRIT', 'USER!ID', '1.2.3.4')
+
+        self.assertEqual(str(exc.exception), "'userid' may not contain '!'")
+
+    def test_ctor_w_token_w_embedded_bang(self):
+        tokens = ('a!b',)  # cannot be safely round-tripped
+
+        with self.assertRaises(ValueError) as exc:
+            self._makeOne('SEEKRIT', 'USERID', '1.2.3.4', tokens=tokens)
+
+        self.assertEqual(
+            str(exc.exception), "'token' values may not contain '!'"
+        )
+
+    def test_ctor_w_token_w_embedded_comma(self):
+        tokens = ('a,b',)  # cannot be safely round-tripped
+
+        with self.assertRaises(ValueError) as exc:
+            self._makeOne('SEEKRIT', 'USERID', '1.2.3.4', tokens=tokens)
+
+        self.assertEqual(
+            str(exc.exception), "'token' values may not contain ','"
+        )
+
+    def test_ctor_w_user_data_w_embedded_bang(self):
+        user_data = 'DATA!HERE' # cannot be safely round-tripped
+
+        with self.assertRaises(ValueError) as exc:
+            self._makeOne('SEEKRIT', 'USERID', '1.2.3.4', user_data=user_data)
+
+        self.assertEqual(str(exc.exception), "'user_data' may not contain '!'")
+
     def test_ctor_explicit(self):
         import hashlib
         tkt = self._makeOne('SEEKRIT', 'USERID', '1.2.3.4', tokens=('a', 'b'),


### PR DESCRIPTION
Closes #37.