### PR TITLE
Correct bytes / str confusion in 'r.w.p.htpasswd.sha1_check'.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ repoze.who Changelog
 2.4.1 (unreleased)
 ------------------
 
+- Handle bytes / string correctly in 'repoze.who.plugins.htpasswd.sha1_check'.
+  Closes #28.
+
 - Switch to use ``pytest`` as the testrunner.
 
 2.4 (2020-06-03)

--- a/repoze/who/plugins/htpasswd.py
+++ b/repoze/who/plugins/htpasswd.py
@@ -100,8 +100,10 @@ def sha1_check(password, hashed):
     from hashlib import sha1
     from base64 import standard_b64encode
     from repoze.who._compat import must_encode
-    encrypted_string = standard_b64encode(sha1(must_encode(password)).digest())
-    return _same_string(hashed, "%s%s" % ("{SHA}", encrypted_string))
+    b_password = must_encode(password)
+    b_sha1_digest = sha1(b_password).digest()
+    b_b64_sha1_digest = standard_b64encode(b_sha1_digest)
+    return _same_string(hashed, b"{SHA}" + b_b64_sha1_digest)
 
 def plain_check(password, hashed):
     return _same_string(password, hashed)

--- a/repoze/who/plugins/tests/test_htpasswd.py
+++ b/repoze/who/plugins/tests/test_htpasswd.py
@@ -120,18 +120,30 @@ class TestHTPasswdPlugin(unittest.TestCase):
         self.assertEqual(crypt_check('password', hashed), True)
         self.assertEqual(crypt_check('notpassword', hashed), False)
 
-    def test_sha1_check(self):
+    def test_sha1_check_w_password_str(self):
         from base64 import standard_b64encode
         from hashlib import sha1
-        from repoze.who._compat import must_encode
         from repoze.who.plugins.htpasswd import sha1_check
 
-        encrypted_string = standard_b64encode(sha1(
-                                must_encode("password")).digest())
-        self.assertEqual(sha1_check('password',
-                         "%s%s" % ("{SHA}", encrypted_string)), True)
-        self.assertEqual(sha1_check('notpassword',
-                         "%s%s" % ("{SHA}", encrypted_string)), False)
+        password = u'password'
+        b_password = password.encode("ascii")
+        encrypted_string = standard_b64encode(sha1(b_password).digest())
+        hashed = b"%s%s" % (b"{SHA}", encrypted_string)
+
+        self.assertTrue(sha1_check(password, hashed))
+        self.assertFalse(sha1_check('notpassword', hashed))
+
+    def test_sha1_check_w_password_bytes(self):
+        from base64 import standard_b64encode
+        from hashlib import sha1
+        from repoze.who.plugins.htpasswd import sha1_check
+
+        b_password = b'password'
+        encrypted_string = standard_b64encode(sha1(b_password).digest())
+        hashed = b"%s%s" % (b"{SHA}", encrypted_string)
+
+        self.assertTrue(sha1_check(b_password, hashed))
+        self.assertFalse(sha1_check(b'notpassword', hashed))
 
     def test_plain_check(self):
         from repoze.who.plugins.htpasswd import plain_check


### PR DESCRIPTION
Closes #28.