### PR TITLE
fix: emit warning / exception from 'crypt_check'

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -232,6 +232,9 @@ nominated to act as authenticator plugins. ::
     use = repoze.who.plugins.htpasswd:make_plugin
     filename = %(here)s/passwd
     check_fn = repoze.who.plugins.htpasswd:crypt_check
+    # The stdlib 'crypt' module is not available for Python > 3.13.  Instead,
+    # use: 'bcrypt.checkpw' function (see https://pypi.org/projects/bcrypt/).
+    # check_fn = bcrypt:checkpw
 
     [plugin:sqlusers]
     # authentication

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -133,6 +133,12 @@ authentication, identification, challenge and metadata provision.
   ``repoze.who.plugins.htpasswd:crypt_check``; it assumes the values
   in the htpasswd file are encrypted with the UNIX ``crypt`` function.
 
+.. note::
+   The ``crypt`` module is not available in the standard library for
+   Python >= 3.13.  Recommended replacement for the checker function
+   we provide here (``repoze.who.plugins.htpasswd:crypt_check``) is the
+   ``bcrypt.checkpw`` function (see https://pypi.org/projects/bcrypt/).
+
 .. module:: repoze.who.plugins.redirector
 
 .. class:: RedirectorPlugin(login_url, came_from_param, reason_param, reason_header)


### PR DESCRIPTION
Point users to 'bcrypt.checkpw' as a better alternative.

Closes #44

/cc @mauritsvanrees 